### PR TITLE
Update EP.xml

### DIFF
--- a/EP.xml
+++ b/EP.xml
@@ -57,7 +57,7 @@ Date: 2022-08-03
     <DEP Enable="true" EmulateAtlThunks="false" />
     <ImageLoad AuditImageLoad="false" PreferSystem32="false" BlockLowLabelImageLoads="false" BlockRemoteImageLoads="true" AuditLowLabelImageLoads="false" AuditRemoteImageLoads="false" />
     <Payload EnableExportAddressFilter="true" EnableExportAddressFilterPlus="true" EnableImportAddressFilter="true" EnableRopStackPivot="true" EnableRopCallerCheck="true" EnableRopSimExec="true" />
-    <ChildProcess DisallowChildProcessCreation="true" Audit="false" />
+    <ChildProcess DisallowChildProcessCreation="false" Audit="false" />
   </AppConfig>
   <AppConfig Executable="fltldr.exe">
     <DEP Enable="true" EmulateAtlThunks="false" />


### PR DESCRIPTION
onedrive.exe needs to launch child processes

Process '\Device\HarddiskVolume7\Program Files\Microsoft OneDrive\OneDrive.exe' (PID 11064) was blocked from creating a child process 'C:\Program Files\Microsoft OneDrive\22.151.0717.0001\Microsoft.SharePoint.exe' with command line '"C:\Program Files\Microsoft OneDrive\22.151.0717.0001\Microsoft.SharePoint.exe" /silentConfig'.